### PR TITLE
Fix bufnr passed to LSP requests in completion source

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ My Neovim configuration with a streamlined plugin setup and improved code foldin
 - Lazy-loaded plugins managed with [lazy.nvim](https://github.com/folke/lazy.nvim)
 - Modern folding using `nvim-ufo` and `statuscol.nvim`
   - Click a line number to fold or unfold the surrounding code
+- Fixes common LSP completion error `bufnr: expected number, got function` by ensuring
+  buffer ids are resolved before requests

--- a/lua/plugins/completions.lua
+++ b/lua/plugins/completions.lua
@@ -11,6 +11,20 @@ return {
     -- },
     {
         "hrsh7th/cmp-nvim-lsp",
+        config = function()
+            -- Ensure that LSP requests use the numeric buffer id.
+            -- Some setups accidentally pass the `vim.api.nvim_get_current_buf`
+            -- function itself which triggers "bufnr: expected number, got function".
+            local source = require("cmp_nvim_lsp.source")
+            local old_request = source._request
+            source._request = function(self, method, params, callback)
+                params = params or {}
+                params.context = params.context or {}
+                -- Resolve the buffer number before forwarding the request.
+                params.context.bufnr = params.context.bufnr or vim.api.nvim_get_current_buf()
+                return old_request(self, method, params, callback)
+            end
+        end,
     },
     {
         "L3MON4D3/LuaSnip",


### PR DESCRIPTION
## Summary
- ensure cmp-nvim-lsp resolves buffer number before making LSP requests
- document LSP completion fix in README

## Testing
- `luacheck lua/plugins/completions.lua README.md` *(fails: command not found)*
- `lua -p lua/plugins/completions.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ea2c9b2c832d9aa9b6a087534a29