### PR TITLE
Normalize buffer numbers in LSP client requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ My Neovim configuration with a streamlined plugin setup and improved code foldin
 - Lazy-loaded plugins managed with [lazy.nvim](https://github.com/folke/lazy.nvim)
 - Modern folding using `nvim-ufo` and `statuscol.nvim`
   - Click a line number to fold or unfold the surrounding code
+- Fixes common LSP completion error `bufnr: expected number, got function` by normalizing
+  buffer numbers in LSP requests

--- a/lua/plugins/completions.lua
+++ b/lua/plugins/completions.lua
@@ -1,3 +1,18 @@
+-- Normalize buffer numbers for LSP requests. Some plugins pass
+-- `vim.api.nvim_get_current_buf` directly which results in "bufnr:
+-- expected number, got function" when the LSP client makes a request.
+local client = require("vim.lsp.client")
+local orig_request = client.request
+client.request = function(self, method, params, handler, bufnr)
+    if type(bufnr) == "function" then
+        bufnr = bufnr()
+    end
+    if type(bufnr) ~= "number" then
+        bufnr = vim.api.nvim_get_current_buf()
+    end
+    return orig_request(self, method, params, handler, bufnr)
+end
+
 return {
     -- {
     --     "git@github.com:hrsh7th/cmp-nvim-lua.git",
@@ -9,9 +24,7 @@ return {
     -- {
     --     "hrsh7th/cmp-buffer",
     -- },
-    {
-        "hrsh7th/cmp-nvim-lsp",
-    },
+    { "hrsh7th/cmp-nvim-lsp" },
     {
         "L3MON4D3/LuaSnip",
         dependencies = {


### PR DESCRIPTION
## Summary
- normalize `bufnr` in all LSP client requests to prevent "bufnr: expected number, got function" errors
- document LSP buffer-number fix in feature list

## Testing
- `luacheck lua/plugins/completions.lua README.md` *(fails: command not found)*
- `lua -p lua/plugins/completions.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ea2c9b2c832d9aa9b6a087534a29